### PR TITLE
[hotfix] fix rl_loop, rl_basic

### DIFF
--- a/src/hpcai/cookbook/recipes/rl_basic.py
+++ b/src/hpcai/cookbook/recipes/rl_basic.py
@@ -14,11 +14,11 @@ from hpcai.cookbook.rl import train
 
 
 def build_config_blueprint() -> chz.Blueprint[train.Config]:
-    model_name = "meta-llama/Llama-3.1-8B"
+    model_name = "Qwen/Qwen3-4B"
     renderer_name = model_info.get_recommended_renderer_name(model_name)
     builder = Gsm8kDatasetBuilder(
-        batch_size=128,
-        group_size=16,
+        batch_size=32,
+        group_size=8,
         renderer_name=renderer_name,
         model_name_for_tokenizer=model_name,
     )

--- a/src/hpcai/lib/api_future_impl.py
+++ b/src/hpcai/lib/api_future_impl.py
@@ -127,7 +127,7 @@ class _APIFuture(APIFuture[T]):  # pyright: ignore[reportUnusedClass]
                     response = await client.futures.with_raw_response.retrieve(
                         request_id=self.request_id,
                         model_id=self.untyped_future.model_id if self.untyped_future.model_id else NOT_GIVEN,
-                        timeout=45,
+                        timeout=300,
                         extra_headers=headers,
                         max_retries=0,
                     )

--- a/src/hpcai/lib/public_interfaces/sampling_client.py
+++ b/src/hpcai/lib/public_interfaces/sampling_client.py
@@ -131,7 +131,6 @@ class SamplingClient(TelemetryProvider, QueueStateObserver):
         include_prompt_logprobs: bool,
     ) -> types.SampleResponse:
         idempotency_key = self.holder.make_idempotency_key()
-        print(idempotency_key)
         async with self.holder._sample_dispatch_semaphore:
             while True:
                 if (


### PR DESCRIPTION
- Fix rl_loop.py and rl_basic.py
- Increase timeout setting for _APIFuture to 300s

# Reproduce
## Set environmental variables
```
export HPCAI_BASE_URL="https://cloud.luchentech.com/finetunesdk"
export HPCAI_API_KEY="YOUR_HPCAI_API_KEY"
# set proxies if needed
export no_proxy="localhost,127.0.0.1,0.0.0.0"
export https_proxy=[http://vpn.luchentech.com:31171](http://vpn.luchentech.com:32171/)
export http_proxy=[http://vpn.luchentech.com:31171](http://vpn.luchentech.com:32171/)
export all_proxy=socks5://[vpn.luchentech.com:31170](http://vpn.luchentech.com:32170/)
```

## Run rl_loop.py
```
cd $HOME/HPC-AI-SDK/src/hpcai/cookbook/recipes
python rl_loop.py
```
<img width="311" height="446" alt="image" src="https://github.com/user-attachments/assets/2e41eb1c-1a1a-4692-b48c-677156fba3d7" />


## Run rl_basic.py
```
cd $HOME/HPC-AI-SDK/src/hpcai/cookbook/recipes
python rl_basic.py
```
<img width="312" height="443" alt="image" src="https://github.com/user-attachments/assets/92295971-6cb3-4fb7-b7af-0b338092cb8c" />